### PR TITLE
Make planning_context load top-level xacro instead of urdf.

### DIFF
--- a/launch/planning_context.launch
+++ b/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" textfile="$(find matilda_support)/urdf/matilda.URDF"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find matilda_support)/urdf/matilda.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find matilda_moveit_config)/config/matilda_support.srdf" />


### PR DESCRIPTION
As per subject.

No need to keep the urdf around. One less file to maintain.
